### PR TITLE
Various bug fixes

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -71,7 +71,7 @@ exports.get = {
               goalDate: goal.endDate,
               goalNumber: goal.goalNumber,
               workoutName: name,
-              workoutHistory,
+              workoutHistory: workoutHistory.sort((a,b) => a.date - b.date),
               workoutPredictions: goal.workoutPredictions
             }
           }

--- a/src/client/components/goal-component/panel/panel.js
+++ b/src/client/components/goal-component/panel/panel.js
@@ -20,6 +20,7 @@ angular.module('sparrowFit')
       console.log($scope.selectedGoal)
       $scope.selectedData = $scope.selectedGoal;
       $scope.onFailure = true;
+      $scope.onSuccess = false;
       $scope.selectedData.workoutPredictions.forEach(prediction => {
         if ($scope.onSuccess || prediction.number >= $scope.selectedData.goalNumber) {
           $scope.onFailure = false;


### PR DESCRIPTION
Workout history is sent in date order on /API/goals endpoint to prevent the more visually stimulating graphs that are sometimes produced.

Removed bug which showed users the wrong message depending on the previous goal they'd viewed.